### PR TITLE
Consider changes on `input` in addition to `blur`

### DIFF
--- a/dist/angular-medium-editor.js
+++ b/dist/angular-medium-editor.js
@@ -5,22 +5,30 @@ angular.module('angular-medium-editor', []).directive('mediumEditor', function (
     restrict: 'AE',
     link: function (scope, iElement, iAttrs, ctrl) {
       angular.element(iElement).addClass('angular-medium-editor');
+      // Parse options
       var opts = {};
       if (iAttrs.options) {
         opts = angular.fromJson(iAttrs.options);
       }
       var placeholder = opts.placeholder || 'Type your text';
-      iElement.on('blur', function () {
+      var onChange = function () {
         scope.$apply(function () {
+          // If user cleared the whole text, we have to reset the editor because MediumEditor
+          // lacks an API method to alter placeholder after initialization
           if (iElement.html() == '<p><br></p>') {
             opts.placeholder = placeholder;
             var editor = new MediumEditor(iElement, opts);
           }
           ctrl.$setViewValue(iElement.html());
         });
-      });
+      };
+      // view -> model
+      iElement.on('blur', onChange);
+      iElement.on('input', onChange);
+      // model -> view
       ctrl.$render = function () {
         if (!editor) {
+          // Hide placeholder when the model is not empty
           if (!ctrl.$isEmpty(ctrl.$viewValue)) {
             opts.placeholder = '';
           }

--- a/dist/angular-medium-editor.min.js
+++ b/dist/angular-medium-editor.min.js
@@ -1,8 +1,8 @@
 /**
  * angular-medium-editor
- * @version v0.0.1 - 2013-11-10
+ * @version v0.0.1 - 2014-03-10
  * @link https://github.com/thijsw/angular-medium-editor
  * @author Thijs Wijnmaalen <thijs@wijnmaalen.name>
  * @license MIT License, http://www.opensource.org/licenses/MIT
  */
-"use strict";angular.module("angular-medium-editor",[]).directive("mediumEditor",function(){return{require:"ngModel",restrict:"AE",link:function(a,b,c,d){angular.element(b).addClass("angular-medium-editor");var e={};c.options&&(e=angular.fromJson(c.options));var f=e.placeholder||"Type your text";b.on("blur",function(){a.$apply(function(){if("<p><br></p>"==b.html()){e.placeholder=f;{new MediumEditor(b,e)}}d.$setViewValue(b.html())})}),d.$render=function(){if(!a){d.$isEmpty(d.$viewValue)||(e.placeholder="");var a=new MediumEditor(b,e)}b.html(d.$isEmpty(d.$viewValue)?"":d.$viewValue)}}}});
+"use strict";angular.module("angular-medium-editor",[]).directive("mediumEditor",function(){return{require:"ngModel",restrict:"AE",link:function(a,b,c,d){angular.element(b).addClass("angular-medium-editor");var e={};c.options&&(e=angular.fromJson(c.options));var f=e.placeholder||"Type your text",g=function(){a.$apply(function(){if("<p><br></p>"==b.html()){e.placeholder=f;{new MediumEditor(b,e)}}d.$setViewValue(b.html())})};b.on("blur",g),b.on("input",g),d.$render=function(){if(!a){d.$isEmpty(d.$viewValue)||(e.placeholder="");var a=new MediumEditor(b,e)}b.html(d.$isEmpty(d.$viewValue)?"":d.$viewValue)}}}});

--- a/src/angular-medium-editor.js
+++ b/src/angular-medium-editor.js
@@ -19,8 +19,7 @@ angular.module('angular-medium-editor', [])
 
         var placeholder = opts.placeholder || 'Type your text';
 
-        // view -> model
-        iElement.on('blur', function() {
+        var onChange = function() {
 
           scope.$apply(function() {
 
@@ -33,13 +32,17 @@ angular.module('angular-medium-editor', [])
 
             ctrl.$setViewValue(iElement.html());
           });
-        });
+        };
+
+        // view -> model
+        iElement.on('blur', onChange);
+        iElement.on('input', onChange);
 
         // model -> view
         ctrl.$render = function() {
 
           if (!editor) {
-            // Hide placeholder when the model is not empty  
+            // Hide placeholder when the model is not empty
             if (!ctrl.$isEmpty(ctrl.$viewValue)) {
               opts.placeholder = '';
             }


### PR DESCRIPTION
Since changes weren't updated on the scope variable
until the element was blurred, it was difficult to 
watch for changes as they were being edited. 

Registering on `input` fixes this for modern 
browsers.
