### PR TITLE
Clear data-placeholder if ng-model isn't empty

### DIFF
--- a/src/angular-medium-editor.js
+++ b/src/angular-medium-editor.js
@@ -45,6 +45,7 @@ angular.module('angular-medium-editor', [])
             // Hide placeholder when the model is not empty
             if (!ctrl.$isEmpty(ctrl.$viewValue)) {
               opts.placeholder = '';
+              iElement[0].dataset.placeholder = '';
             }
 
             var editor = new MediumEditor(iElement, opts);

--- a/src/angular-medium-editor.js
+++ b/src/angular-medium-editor.js
@@ -45,7 +45,11 @@ angular.module('angular-medium-editor', [])
             // Hide placeholder when the model is not empty
             if (!ctrl.$isEmpty(ctrl.$viewValue)) {
               opts.placeholder = '';
-              iElement[0].dataset.placeholder = '';
+
+              angular.forEach(iElement, function(element) {
+                if (typeof(element.dataset.placeholder) != 'undefined')
+                  element.dataset.placeholder = '';
+              });
             }
 
             var editor = new MediumEditor(iElement, opts);


### PR DESCRIPTION
Using angular-medium-editor I define elements like the following

    <h1 ng-model="$storage.resourceContent.name" class="input-block-level" medium-editor
        options="{{editorMinOptions}}" data-placeholder="title">

The problem is that if the model isn't empty, the placeholder won't be emptied. That's why I did this modification in order to empty the data-placeholder if the ng-model is already set.