### PR TITLE
Use $eval() instead of fromJson() to enable variable binding

### DIFF
--- a/src/angular-medium-editor.js
+++ b/src/angular-medium-editor.js
@@ -14,7 +14,7 @@ angular.module('angular-medium-editor', [])
         // Parse options
         var opts = { };
         if (iAttrs.options) {
-          opts = angular.fromJson(iAttrs.options);
+          opts = scope.$eval(iAttrs.options);
         }
 
         var placeholder = opts.placeholder || 'Type your text';


### PR DESCRIPTION
Would be nice to support options in scope variables. Also not a fan of strict JSON syntax in html attributes. 
