### PR TITLE
medium-editor-insert-plugin integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ Paragraph with support for multiple lines and customized toolbar buttons
 <p ng-model="description" medium-editor options='{"placeholder": "Enter a description", "buttons": ["bold", "italic", "underline", "anchor", "header1", "header2", "quote", "orderedlist", "unorderedlist"]}'></p>
 ```
 
+Integrating with [medium-editor-insert-plugin](https://github.com/orthes/medium-editor-insert-plugin)
+```html
+<script src="path/to/medium-editor-insert-plugin.all.min.js"></script>
+<div ng-model="description" medium-editor options='{"addons": { "images": {} } }'></div>
+```
+
 _(More coming soon)_
 
 ## Examples

--- a/src/angular-medium-editor.js
+++ b/src/angular-medium-editor.js
@@ -2,7 +2,7 @@
 
 angular.module('angular-medium-editor', [])
 
-  .directive('mediumEditor', function() {
+  .directive('mediumEditor', function($timeout) {
 
     return {
       require: 'ngModel',
@@ -19,6 +19,19 @@ angular.module('angular-medium-editor', [])
 
         var placeholder = opts.placeholder || 'Type your text';
 
+        var createEditor = function(options) {
+          var editor = new MediumEditor(iElement, options);
+          if(options.addons && iElement.mediumInsert) {
+            $timeout(function() {
+              iElement.mediumInsert({
+                editor: editor,
+                addons: options.addons
+              });
+            });
+          }
+          return editor;
+        };
+
         var onChange = function() {
 
           scope.$apply(function() {
@@ -27,7 +40,7 @@ angular.module('angular-medium-editor', [])
             // lacks an API method to alter placeholder after initialization
             if (iElement.html() == '<p><br></p>') {
               opts.placeholder = placeholder;
-              var editor = new MediumEditor(iElement, opts);
+              var editor = createEditor(opts);
             }
 
             ctrl.$setViewValue(iElement.html());
@@ -47,7 +60,7 @@ angular.module('angular-medium-editor', [])
               opts.placeholder = '';
             }
 
-            var editor = new MediumEditor(iElement, opts);
+            var editor = createEditor(opts);
           }
 
           iElement.html(ctrl.$isEmpty(ctrl.$viewValue) ? '' : ctrl.$viewValue);


### PR DESCRIPTION
The MediumEditor is a lot nicer when having the opportunity to upload images and stuff. This makes it possible to optionally integrate with [medium-editor-insert-plugin](https://github.com/orthes/medium-editor-insert-plugin) by passing an `addons` argument in options.
