### PR TITLE
Add ignore property to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,5 +5,13 @@
     "angular": "1.3.*",
     "medium-editor": "5.*"
   },
-  "main": "./dist/angular-medium-editor.js"
+  "main": "./dist/angular-medium-editor.js",
+  "ignore": [
+    "**/.*",
+    "*.md",
+    "Gruntfile.js",
+    "package.json",
+    "src",
+    "demo"
+  ]
 }


### PR DESCRIPTION
To get rid of alert: 
```
angular-medium-editor#~1.1.0 invalid-meta angular-medium-editor is missing "ignore" entry in bower.json
```

https://github.com/bower/spec/blob/master/json.md#ignore