### PR TITLE
Update README.md to reflect v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,64 @@
 # angular-medium-editor
-This is an AngularJS directive for the [medium.com inline editor clone](https://github.com/daviferreira/medium-editor) made by Davi Ferreira.
+This is an AngularJS directive for the [Medium.com inline editor clone](https://github.com/daviferreira/medium-editor) by Davi Ferreira.
 
+## Install
 
-## Getting Started
-
-Download the [production version][min] or the [development version][max].
-
-[min]: https://raw.github.com/thijsw/angular-medium-editor/master/dist/angular-medium-editor.min.js
-[max]: https://raw.github.com/thijsw/angular-medium-editor/master/dist/angular-medium-editor.js
-
-In your web page:
-
-```html
-<script src="angular.js"></script>
-<script src="dist/angular-medium-editor.min.js"></script>
-```
-
-## Demo
-If you want to view the included demo, you have to run bower first in order to retrieve the dependencies.
-
+Install with [Bower](https://bower.io/):
 ```sh
 $ bower install --save angular-medium-editor
 ```
 
+Then add `<script>` to your `index.html`:
+
+```html
+<script src="/bower_components/angular-medium-editor/dist/angular-medium-editor.js"></script>
+```
+
+Remember to include Angular and [Medium editor](https://github.com/daviferreira/medium-editor) before the directive.
+
+Then add `angular-medium-editor` as a dependency for your app:
+
+```javascript
+angular.module('myApp', ['angular-medium-editor']);
+```
+
 ## Documentation
+
+Use as an element:
+```html
+<medium-editor></medium-editor>
+```
+
+...or attribute:
+```html
+<p medium-editor></p>
+```
+
+Pass options with `bind-options` attribute:
+```html
+<p medium-editor bind-options="options"></p>
+```
+
+See MediumEditor's [options documentation](https://github.com/yabwe/medium-editor#mediumeditor-options) for details.
+
+## Examples
+
+#### Single line, no toolbar
 Header example limited to one line and no toolbar
 ```html
-<h1 ng-model="title" medium-editor options='{"placeholder": "Enter a title", "disableToolbar": true, "forcePlainText": true, "disableReturn": true}'></h1>
+<h1 ng-model="title" medium-editor bind-options="{disableReturn: true, disableExtraSpaces: true, toolbar: false}" data-placeholder="Enter a title"></h1>
 ```
 
+#### Multiline with custom toolbar
 Paragraph with support for multiple lines and customized toolbar buttons
 ```html
-<p ng-model="description" medium-editor options='{"placeholder": "Enter a description", "buttons": ["bold", "italic", "underline", "anchor", "header1", "header2", "quote", "orderedlist", "unorderedlist"]}'></p>
+<p ng-model="description" medium-editor bind-options="{'toolbar': {'buttons': ['bold', 'italic', 'underline']}}" data-placeholder="Enter a description"></p>
 ```
 
-Example for extending the toolbar with customized element 'highlighter' (using [rangy](https://code.google.com/p/rangy/) and the [CSS Class Applier Module](https://code.google.com/p/rangy/wiki/CSSClassApplierModule) to support highlighting of text). For more detailed info on extensions, please refer to [MediumEditor](https://github.com/daviferreira/medium-editor).
+#### Custom extension
+Example for extending the toolbar with customized element `highlighter` (using [rangy](https://code.google.com/p/rangy/) and the [CSS Class Applier Module](https://code.google.com/p/rangy/wiki/CSSClassApplierModule) to support highlighting of text). For more detailed info on extensions, please refer to [MediumEditor](https://github.com/daviferreira/medium-editor).
 ```html
-<p ng-model="text" medium-editor options='{"buttons": ["bold", "italic", "highlight"]}' bind-options="mediumBindOptions"></p>
+<p ng-model="text" medium-editor bind-options="mediumBindOptions"></p>
 ```
 ```javascript
 function Highlighter() {
@@ -62,14 +84,23 @@ Highlighter.prototype.checkState = function(node) {
 };
 
 scope.mediumBindOptions = {
+  toolbar: {
+    buttons: ['bold', 'italic', 'highlight']
+  },
   extensions: {
-    'highlight': new Highlighter()
+    highlight: new Highlighter()
   }
 };
 ```
 
-_(More coming soon)_
+## Running the demo
+If you want to view the included demo, you have to run `bower` first in order to retrieve the dependencies.
 
-## Examples
-_(Coming soon)_
+## License
+The MIT License
 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
In par with https://github.com/thijsw/angular-medium-editor/pull/34

- Clarify install instructions
- Add actual documentation
- Move old documentation stuff to "examples"
- Modify examples to work with new version (remove `options`, use only `bind-options`, new options model due MediumEditor v5.x etc)
- Add license text (I saw you were using MIT at package.json)

This is how it would look after this: https://github.com/simison/angular-medium-editor/blob/03542c7934c2e5032d67b89e47e3a92e1a2d5ad5/README.md