### PR TITLE
Fix: destroy MediumEditor instance on scope $destroy

### DIFF
--- a/src/angular-medium-editor.js
+++ b/src/angular-medium-editor.js
@@ -46,6 +46,10 @@ angular.module('angular-medium-editor', [])
         scope.$watch('bindOptions', function(bindOptions) {
           ngModel.editor.init(iElement, bindOptions);
         });
+
+        scope.$on('$destroy', function() {
+          ngModel.editor.destroy();
+        });
       }
     };
 


### PR DESCRIPTION
Before this, html would be full of Medium editor’s div leftovers.

Fixes #37
Fixes #24
Duplicate of #38 (sorry, I just want to get this forward and there was quite a bit of refactoring in between). Apparently also dupe of #52.

This also doesn't include dist files, I figured better if @thijsw generates them before new version. Lemme know if I should include them.